### PR TITLE
pyct 0.4.8 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,31 +11,45 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  entry_points:
+    - pyct=pyct.__main__:main
 
 requirements:
   host:
     - param >=1.7.0
     - python
     - pip
+    - setuptools >=30.3.0
+    - wheel
   run:
     - param >=1.7.0
     - python
+    # extras_require for 'cmd':
     - pyyaml
     - requests
 
 test:
   imports:
     - pyct
+    - pyct.build
     - pyct.cmd
+  requires:
+    - pip
+  commands:
+    - pip check || true    # [not win]
+    - pip check || exit 0  # [win]
+    - pyct --help
 
 about:
-  home: http://github.com/pyviz/pyct
-  license: BSD 3-Clause
+  home: https://github.com/pyviz/pyct
+  license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
   summary: python package common tasks for users (e.g. copy examples, fetch data, ...)
+  dev_url: https://github.com/pyviz/pyct
+  doc_url: https://github.com/pyviz-dev/pyct/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
`datashader 0.14.1` requires `pyct >=0.4.5` https://github.com/AnacondaRecipes/datashader-feedstock/pull/2, but we are missing artifacts
Rebuild for python 3.9 and 3.10 support.

License: https://github.com/pyviz-dev/pyct/blob/v0.4.8/LICENSE.txt
Changelog: https://github.com/pyviz-dev/pyct/releases/
Requirements:
- https://github.com/pyviz-dev/pyct/blob/v0.4.8/pyproject.toml
- https://github.com/pyviz-dev/pyct/blob/v0.4.8/setup.py

Actions:
1. Bump build number to `1`
2. Add `entry_points`
3. Add missing packages `setuptools`, `wheel`
4. Update `test/imports`
5. Add `pip check`
6. Add the command `pyct --help`
7. Fix home url
8. Fix license name
9. Add dev, doc urls